### PR TITLE
feat: 统一代码风格, 设置 http statuscode 异步读取文件, 并将 ts-node 添加到 dev-dependency 中

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1576,12 +1576,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1596,17 +1598,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1723,7 +1728,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1735,6 +1741,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1749,6 +1756,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1756,12 +1764,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1780,6 +1790,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1860,7 +1871,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1872,6 +1884,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1993,6 +2006,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,6 +306,12 @@
         }
       }
     },
+    "arg": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npm.taobao.org/arg/download/arg-4.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Farg%2Fdownload%2Farg-4.1.1.tgz",
+      "integrity": "sha1-SF+OfDkM5MX3glfb6oDUvhH+2kw=",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -633,6 +639,12 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
       "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "http://registry.npm.taobao.org/buffer-from/download/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -1576,14 +1588,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1598,20 +1608,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1728,8 +1735,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1741,7 +1747,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1756,7 +1761,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1764,14 +1768,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1790,7 +1792,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1871,8 +1872,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1884,7 +1884,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2006,7 +2005,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2661,6 +2659,12 @@
       "requires": {
         "pify": "^3.0.0"
       }
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "http://registry.npm.taobao.org/make-error/download/make-error-1.3.5.tgz",
+      "integrity": "sha1-7+ToH22yjK3WBccPKcgxtY73dsg=",
+      "dev": true
     },
     "map-cache": {
       "version": "0.2.2",
@@ -4065,6 +4069,16 @@
         "urix": "^0.1.0"
       }
     },
+    "source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.13.tgz?cache=0&sync_timestamp=1564565500102&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsource-map-support%2Fdownload%2Fsource-map-support-0.5.13.tgz",
+      "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -4292,6 +4306,27 @@
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
       "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
       "dev": true
+    },
+    "ts-node": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npm.taobao.org/ts-node/download/ts-node-8.3.0.tgz",
+      "integrity": "sha1-5AWWGEETcZJKH7XzsSWRXzJO+1c=",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "http://registry.npm.taobao.org/diff/download/diff-4.0.1.tgz",
+          "integrity": "sha1-DGZ8tGfru1zqfxTxNcwtuneAqP8=",
+          "dev": true
+        }
+      }
     },
     "tslib": {
       "version": "1.10.0",
@@ -4659,6 +4694,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npm.taobao.org/yn/download/yn-3.1.1.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyn%2Fdownload%2Fyn-3.1.1.tgz",
+      "integrity": "sha1-HodAGgnXZ8HV6rJqbkwYUYLS61A=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "nodemon": "^1.17.4",
     "prettier": "^1.18.2",
     "sinon": "^5.0.7",
+    "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
     "typescript": "^2.4.1"
   }

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -20,6 +20,6 @@ describe('Index Controller', function() {
   it('Can get get json', () => {
     indexController.msg(null, res)
     const data = JSON.parse(res._getData())
-    expect(data.msg).to.equal('Hello!')
+    expect(data.msg).to.equal('Welcome to OI-wiki!')
   })
 })

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,12 +1,13 @@
 import { sync } from 'glob'
 import { union } from 'lodash'
+import { env } from 'process'
 
 export default class Config {
   public static port: number = 3000
   public static routes: string = './dist/routes/**/*.js'
   public static models: string = './dist/models/**/*.js'
   public static useMongo: boolean = false
-  public static baseFolder: string = '/home/ir1d/Documents/repo/OI-wiki'
+  public static baseFolder: string = env.OI_WIKI_PATH || '/home/ir1d/Documents/repo/OI-wiki'
   public static mongodb =
     process.env.NODE_ENV === 'docker'
       ? 'mongodb://mongo:27017/express-typescript-starter'

--- a/src/controllers/index.server.controller.ts
+++ b/src/controllers/index.server.controller.ts
@@ -6,7 +6,7 @@ export default class IndexController {
   }
 
   public msg(req: Request, res: Response): void {
-    res.json({ msg: 'Hello!' })
+    res.json({ msg: 'Welcome to OI-wiki!' })
   }
 }
 

--- a/src/controllers/wiki.server.controller.ts
+++ b/src/controllers/wiki.server.controller.ts
@@ -3,41 +3,42 @@ import Config from '../config/config'
 import * as path from 'path'
 import * as fs from 'fs'
 import * as _ from 'lodash'
+import { promisify } from 'util'
+
+const readFileAsync = promisify(fs.readFile)
 
 export default class IndexController {
   public index(req: Request, res: Response, next: Function): void {
     res.render('index', { title: 'Express' })
   }
 
-  public wiki(req: Request, res: Response): void {
+  public async wiki(req: Request, res: Response): Promise<void> {
     try {
       let requested_path = req.params['0']
       requested_path = _.trim(requested_path, '/')
       let file_path =
         path.join(Config.baseFolder, 'docs', requested_path) + '.md'
-      let file_ = fs.readFileSync(file_path, 'utf8')
-      let result = file_
+      let result = await readFileAsync(file_path, 'utf8')
       res.send({ results: result })
     } catch (e) {
       console.error(e)
       res.statusCode = 404
-      res.send({ message: 'page node found' })
+      res.send({ message: 'page not found' })
     }
   }
-  public raw(req: Request, res: Response): void {
+  public async raw(req: Request, res: Response): Promise<void> {
     try {
       let requested_path = req.params['0']
       requested_path = _.trim(requested_path, '/')
       let file_path =
         path.join(Config.baseFolder, 'docs', requested_path) + '.md'
-      let file_ = fs.readFileSync(file_path, 'utf8')
-      let result = file_
+      let result = await readFileAsync(file_path, 'utf8')
       res.setHeader('Content-Type', 'text/plain')
       res.send(result)
     } catch (e) {
       console.error(e)
       res.statusCode = 404
-      res.send({ message: 'page node found' })
+      res.send({ message: 'page not found' })
     }
   }
 }

--- a/src/controllers/wiki.server.controller.ts
+++ b/src/controllers/wiki.server.controller.ts
@@ -1,44 +1,45 @@
-import { Request, Response } from "express";
-// import { inspect } from "util";
-import Config from "../config/config";
-import * as path from "path";
-import * as fs from "fs";
-import * as _ from "lodash";
+import { Request, Response } from 'express'
+import Config from '../config/config'
+import * as path from 'path'
+import * as fs from 'fs'
+import * as _ from 'lodash'
 
 export default class IndexController {
   public index(req: Request, res: Response, next: Function): void {
-    res.render("index", { title: "Express" });
+    res.render('index', { title: 'Express' })
   }
 
   public wiki(req: Request, res: Response): void {
     try {
-      let requested_path = req.params["0"];
-      requested_path = _.trim(requested_path, "/");
+      let requested_path = req.params['0']
+      requested_path = _.trim(requested_path, '/')
       let file_path =
-        path.join(Config.baseFolder, "docs", requested_path) + ".md";
-      let file_ = fs.readFileSync(file_path, "utf8");
-      let result = file_;
-      res.send({ status: 1, results: result });
+        path.join(Config.baseFolder, 'docs', requested_path) + '.md'
+      let file_ = fs.readFileSync(file_path, 'utf8')
+      let result = file_
+      res.send({ results: result })
     } catch (e) {
-      console.log(e);
-      res.send({ status: 0 });
+      console.error(e)
+      res.statusCode = 404
+      res.send({ message: 'page node found' })
     }
   }
   public raw(req: Request, res: Response): void {
     try {
-      let requested_path = req.params["0"];
-      requested_path = _.trim(requested_path, "/");
+      let requested_path = req.params['0']
+      requested_path = _.trim(requested_path, '/')
       let file_path =
-        path.join(Config.baseFolder, "docs", requested_path) + ".md";
-      let file_ = fs.readFileSync(file_path, "utf8");
-      let result = file_;
-      res.setHeader("Content-Type", "text/plain");
-      res.send(result);
+        path.join(Config.baseFolder, 'docs', requested_path) + '.md'
+      let file_ = fs.readFileSync(file_path, 'utf8')
+      let result = file_
+      res.setHeader('Content-Type', 'text/plain')
+      res.send(result)
     } catch (e) {
-      console.log(e);
-      res.send({ status: 0 });
+      console.error(e)
+      res.statusCode = 404
+      res.send({ message: 'page node found' })
     }
   }
 }
 
-export const wikiController = new IndexController();
+export const wikiController = new IndexController()

--- a/src/routes/index.server.route.ts
+++ b/src/routes/index.server.route.ts
@@ -1,12 +1,12 @@
-import { Express } from "express";
-import { indexController } from "../controllers/index.server.controller";
-import { wikiController } from "../controllers/wiki.server.controller";
+import { Express } from 'express'
+import { indexController } from '../controllers/index.server.controller'
+import { wikiController } from '../controllers/wiki.server.controller'
 
 export default class IndexRoute {
   constructor(app: Express) {
-    app.route("/").get(indexController.index);
-    app.route("/msg").get(indexController.msg);
-    app.route("/wiki/*").get(wikiController.wiki);
-    app.route("/wikiraw/*").get(wikiController.raw);
+    app.route('/').get(indexController.index)
+    app.route('/msg').get(indexController.msg)
+    app.route('/wiki/*').get(wikiController.wiki)
+    app.route('/wikiraw/*').get(wikiController.raw)
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,6 @@
       "eofline": true,
       "forin": true,
       "indent": [true, "spaces"],
-      "linebreak-style": [true, "LF"],
       "interface-name": false,
       "jsdoc-format": true,
       "label-position": true,
@@ -47,7 +46,7 @@
       ],
       "quotemark": [true, "single"],
       "radix": true,
-      "semicolon": [false, "always"],
+      "semicolon": [true, "never"],
       "switch-default": true,
       "triple-equals": [true, "allow-null-check"],
       "typedef": [
@@ -79,4 +78,3 @@
       ]
     }
   }
-  


### PR DESCRIPTION
去除了所有分号, 将所有双引号替换为单引号, 去除了重复的 status code, 将 base folder 设置为默认从环境变量读取

BREAKING CHANGE: wiki 和 wikiraw  的 response 中不再存在 status 字段

ts-node 在测试的时候被使用了, 但是没有被添加进依赖